### PR TITLE
Added Dockerfile and steps in README on how to use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16.17
+SHELL ["/bin/bash"]
+RUN ["npm", "i", "-g", "@fluencelabs/cli@0.3.8"]
+COPY . /opt/frpc-substrate
+
+# Install base packages
+WORKDIR /opt/frpc-substrate/gateway
+RUN ["npm", "i"]
+
+# Expose the listening port
+EXPOSE 3000
+
+RUN ["fluence", "aqua", "-i", "aqua/", "-o", "aqua-compiled/", "--js"]
+CMD ["node", "src/index.js", "configs/quickstart_config.json"]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Server was started on port 3000
 
 ```
 
+Alternatively, you can run the gateway as a Docker container by running the following commands (must be run from the base of the repo rather than from the *gateway* folder): 
+```
+docker build -t frpc-gateway .
+docker run -p 3000:3000 frpc-gateway
+```
+
 With the gateway ready for action, all you have to do is change your dApps HTTP transport url to `http://127.0.0.1:3000` and keep using your dApp as usual. In the absence of a dAPP, we can interact with the gateway from the command line:
 
 ```bash
@@ -135,7 +141,7 @@ Call will be to : https://frequent-sleek-river.ethereum-goerli.discover.quiknode
 
 ```
 
-Success! Go ahead and replace the `round-robin` mode with the `random` mode in your config file, stop and start the gateway and have a look at the different endpoint management.
+Success! Go ahead and replace the `round-robin` mode with the `random` mode in your config file, stop and start the gateway and have a look at the different endpoint management. Note that if you are using the Docker approach, you will need to re-run the `docker build` and `docker run` commands after making the config file change in order for the change to take effect. 
 
 Congrat's, you just took a major step toward keeping you dAPP decentralized, available and performant! Now it's time to dive into the Fluence protocol and technology stack to learn how to improve upon the basic substrate and compete for hackathon bounties.
 


### PR DESCRIPTION
I created a Dockerfile in order to run the gateway as a container and figured it could be beneficial to other developers interested in using the fRPC Gateway. The benefits of the container approach are:
- Easier portability to run gateway in a shared location for use by teams (such as on a cloud server/ container service like Amazon ECS) 
- Fewer manual steps to run gateway
- Less package clutter on your local machine 

I added documentation to the README that should be sufficient to get the container running, assuming the user already has Docker installed locally. There is an assumption that the config file with providers is edited prior to the Dockerfile being built since that file is copied directly into the container's filesystem, which is why the steps to use the container come after the config file steps in the README. The `curl` test provided in the README should be sufficient to test the gateway running in the container without any extra steps since the documented `docker run` command exposes port 3000. 

Please let me know if you have any questions or run into any issues while testing. Thank you! 